### PR TITLE
Fix #1. Calculate Belt length

### DIFF
--- a/belt.scad
+++ b/belt.scad
@@ -28,5 +28,10 @@ module belt(size=2) {
   }
 }
 
-// TODO actually calculate this
-function belt_distance(belt_length, gear_size1, gear_size2) = belt_length/2;
+// This an approximation for a transcendental equation, but seems to work well
+// see this post: https://math.stackexchange.com/questions/123361
+function gear_center_distance(belt_length, gear_size1, gear_size2) =
+  let(diff=abs(gear_size1 - gear_size2))
+  let(tangent_length=
+    (belt_length - PI*diff + sqrt(sqr(PI*diff - belt_length) - 16*sqr(diff))) / 4)
+  sqrt(sqr(diff) + sqr(tangent_length));

--- a/frame.scad
+++ b/frame.scad
@@ -16,12 +16,12 @@ cube_to_arm_len = 80;
 
 cube_spinner_belt_size = 120;
 
-cube_spinner_servo_belt_distance = belt_distance(
+cube_spinner_servo_gear_center_distance = gear_center_distance(
                                 cube_spinner_belt_size,
                                 servo_gear_thickness,
                                 servo_gear_thickness * 2);
 
-cube_spinner_servo_offset = sqrt(sqr(cube_spinner_servo_belt_distance), sqr(width + servo_block_size[1]/2));
+cube_spinner_servo_offset = sqrt(sqr(cube_spinner_servo_gear_center_distance), sqr(width + servo_block_size[1]/2));
 
 cube_spinner_servo_support_offset = servo_block_size[0]/2 + servo_screw_offsets[1]/2;
 cube_spinner_servo_support_height = servo_gear_thickness


### PR DESCRIPTION
Use an approximation to calculate the distance between the center point of two gears surrounded by a belt of known length.